### PR TITLE
Add reference to LDK architecture

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -3,7 +3,7 @@ id: references
 title: References
 ---
 
-### [Rust Documentation](https://docs.rs/lightning/0.0.12/lightning/index.html)
+### [Rust Documentation](https://docs.rs/lightning)
 
 These provide the most searchable and comprehensive documentation on LDK.
 If you're using Java and want more information on any method/struct/etc., searching

--- a/docs/references.md
+++ b/docs/references.md
@@ -18,3 +18,8 @@ a lightning node using LDK.
 
 These docs are mainly geared towards how Swift could call LDK C bindings directly, but still may
 provide a useful overview of Rust Lightning in the context of language bindings.
+
+### [LDK Architecture](https://docs.google.com/drawings/d/1Ql-q5gyrPnJhi7z_D39jayG0HEEVh6UEY1eULXb03Eg/edit?usp=sharing)
+
+Gives a high-level organization of LDK and how the pieces fit together. Variations of this diagram
+are used throughout the site. This is the primary source and is still a work in progress.

--- a/docs/references.md
+++ b/docs/references.md
@@ -3,15 +3,18 @@ id: references
 title: References
 ---
 
-* Rust documentation: https://docs.rs/lightning/0.0.12/lightning/index.html
+### [Rust Documentation](https://docs.rs/lightning/0.0.12/lightning/index.html)
+
 These provide the most searchable and comprehensive documentation on LDK.
 If you're using Java and want more information on any method/struct/etc., searching
 the Rust docs for the Rust version of that struct/method is your best bet.
 
-* Rust sample node: https://github.com/TheBlueMatt/rust-lightning-bitcoinrpc
+### [Rust Sample Node](https://github.com/TheBlueMatt/rust-lightning-bitcoinrpc)
+
 While this node is a little outdated, it's still a very useful reference for how to construct
 a lightning node using LDK.
 
-* Swift LDK documentation: https://github.com/arik-so/SwiftLightning/tree/master/Documentation
+### [Swift LDK Documentation](https://github.com/arik-so/SwiftLightning/tree/master/Documentation)
+
 These docs are mainly geared towards how Swift could call LDK C bindings directly, but still may
 provide a useful overview of Rust Lightning in the context of language bindings.


### PR DESCRIPTION
Adds a link to the the LDK architecture diagram in the References page. Also:
- updates Reference page's formatting (alternative ideas welcome)
- links to the most recent rust-lightning docs rather than a specific version

Partial work towards #15.