### PR TITLE
Update BackgroundProcessor init in Build a Node guide

### DIFF
--- a/docs/build_node_rust.md
+++ b/docs/build_node_rust.md
@@ -742,7 +742,7 @@ let persist_channel_manager_callback = move |node: &ChannelManager| {
 
 **Example:**
 ```rust
-BackgroundProcessor::start(
+let background_processor = BackgroundProcessor::start(
 	persist_channel_manager_callback,
 	handle_event_callback,
 	&chain_monitor,


### PR DESCRIPTION
In Rust, an upcoming change will stop the `BackgroundProcessor`'s thread when the object is dropped. Update the guide to store the `BackgroundProcessor` in a variable otherwise the thread would be stopped immediately after it is started.