### PR TITLE
Make filter initialization compile

### DIFF
--- a/docs/build_node_rust.md
+++ b/docs/build_node_rust.md
@@ -209,8 +209,8 @@ let filter = YourTxFilter();
 **Example:**
 
 ```rust
-let filter: Option<Filter> = // leave this as None or insert the Filter trait
-                             // object, depending on what you did for Step 5
+let filter: Option<Box<dyn Filter>> = // leave this as None or insert the Filter trait
+                                      // object, depending on what you did for Step 5
 
 let chain_monitor = ChainMonitor::new(
     filter, &broadcaster, &logger, &fee_estimator, &persister


### PR DESCRIPTION
I think `Box<dyn>` is maybe the simplest to understand for new Rust users. We could also use `Arc<dyn>` or simply `&dyn `.

Addresses the issue noted at https://github.com/lightningdevkit/lightningdevkit.org/discussions/55#discussioncomment-1044139