### PR TITLE
Reflect removed return value of `register_output`

### DIFF
--- a/docs/blockchain_data/pre_filtered_blocks.md
+++ b/docs/blockchain_data/pre_filtered_blocks.md
@@ -21,13 +21,9 @@ impl chain::Filter for Blockchain {
 		// <insert code for you to watch for this transaction on-chain>
 	}
 
-	fn register_output(&self, output: WatchedOutput) -> Option<(usize, Transaction)> {
+	fn register_output(&self, output: WatchedOutput) {
 		// <insert code for you to watch for any transactions that spend this
 		// output on-chain>
-		// If you are fetching pre-filtered blocks, and do not fetch in-block
-		// descendants of transactions, return any in-block spend of the given
-		// output.
-		// Otherwise return None.
 	}
 }
 ```
@@ -43,13 +39,9 @@ Filter tx_filter = Filter.new_impl(new Filter.FilterInterface() {
 	}
 
 	@Override
-	Option_C2Tuple_usizeTransactionZZ register_output(WatchedOutput output) {
+	public void register_output(WatchedOutput output) {
 		// <insert code for you to watch for any transactions that spend this
 		// output on-chain>
-		// If you are fetching pre-filtered blocks, and do not fetch in-block
-		// descendants of transactions, return any in-block spend of the given
-		// output.
-		// Otherwise return Option_C2Tuple_usizeTransactionZZ.none().
 	}
 });
 ```


### PR DESCRIPTION
This reflects the changes made to the `Filter::register_output` interface in [rust-lightning#1663](https://github.com/lightningdevkit/rust-lightning/pull/1663). 

Should hence only get merged after/if this lands.