### PR TITLE
Remove outdated LDK+BDK sample

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -15,10 +15,6 @@ This repository contains a sample implementation of LDK as the result of followi
 
 Kotlin based CLI lightning network server based on LDK. Provides HTTP-RPC interface.
 
-### [LDK + BDK Sample Node](https://github.com/johncantrell97/ldk-bdk-sample)
-
-This library hopes to bridge the gap needed to implement a LDK-based lightning client using a `bdk::Wallet`.
-
 ### [Rust node with sample Lightning Signer integration](https://gitlab.com/lightning-signer/lnrod/)
 
 A Rust Lightning node implementation based on the LDK and the Lightning Signer projects. Aims to be production ready at some point.


### PR DESCRIPTION
Context:
```
4:09 PM]swally234: Happy Friday all! I'm taking a look at bdk<->ldk integration to use BDK as my chain backend. I've been digging in @johncantrell97 's IndexedChain implementation and noticed this isn't available in BDK as of yet. Is this still the way to go? Has there been other lines of progress made on integration that I should look at since John's work?
[4:10 PM]johncantrell97: I should delete that repo, it's definitely not the way to go anymore 🙂
[4:11 PM]johncantrell97: You should look at https://github.com/lightningdevkit/ldk-lite if you're working in rust and want to use esplora 
[4:11 PM]johncantrell97: if you want to use bitcoin core you can look at sensei
[4:11 PM]swally234: Looks like the LDK site is linking out to that repo atm too
[4:12 PM]johncantrell97: yikes, ok ill get that updated. thanks
[4:12 PM]swally234: Nice one! That's really helpful. I appreciate it 👍🏻
```