### PR TITLE
Add a general CoC for LDK contributors

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -229,6 +229,11 @@ module.exports = {
               link: "http://ldk.reviews/",
               rel: 'noopener noreferrer'
             },
+            {
+              text: 'Code of Conduct',
+              link: "/code_of_conduct",
+              rel: 'noopener noreferrer'
+            },
           ]
         },
         {

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -1,0 +1,73 @@
+# LDK Code of Conduct
+
+The LDK community is open to pretty much anyone. To ensure that project forums such as the Discord server and GitHub repository are open and friendly, we count on maintainers and project representatives to behave in a way that is not disruptive to LDK's culture or to any one participant's well-being.
+
+Therefore, we came up with some easy to follow guidelines.
+ * Be friendly. Interact in a way that fosters openness, inclusivity, and collaboration.
+ * Be respectful. We may disagree, but disagreement is no excuse for rude behavior or personal attacks.
+ * Be considerate. Provide and accept constructive criticism.
+
+Private or public harassment of any kind will not be tolerated. Since harassment can take many forms, here's a non-exhaustive list of what we consider unacceptable behavior:
+ * Offensive language directed at individuals or groups of people
+ * Bullying (verbal, physical, social, or cyber)
+ * Interfering with someone's ability to contribute, like with excessive nitpicking
+ * Continued one-on-one communication after a party has requested it cease
+ * Stalking online or offline
+ * Doxing or unauthorized publication of private information or communication
+ * Unwelcomed sexual attention
+ * Inappropriate visual displays such as sexually-oriented or offensive  photography, cartoons, drawings, or gestures
+ * Retaliation for reporting or threatening to report harassment
+
+Additionally, spam and other content which disrupts or prevents LDK contributors from working on LDK is not acceptable.
+
+## The Code of Conduct Team
+
+A small team of LDK contributors has volunteered to enforce the LDK Code of Conduct. If you feel like a community member has engaged in inappropriate behavior, please don't hesitate to contact one of the following LDK contributors via email or on Discord:
+ * Matt Corallo - ldkcocpoc on mattcorallo.com
+ * Val Wallace - vwallace on protonmail.com
+ * Devrandom - devrandom99 on proton.me
+
+## The Code of Conduct Team’s Responsibilities
+
+Team members are tasked with responding to reports within 24 hours. They will review each incident and determine, to the best of their ability:
+ * Does the event constitute a Code of Conduct violation?
+ * Is the behavior on our list of inappropriate behavior? Is it borderline inappropriate?
+ * Did the event occur in a space within our Code of Conduct's scope?
+   * If the incident occurred outside community forums and the individual is seen as a project representative or identifies as an LDK contributor, the incident may be in scope.
+   * Additionally, an incident may be in scope if a community member's ability to contribute to LDK is impacted.
+ * Did this incident occur in a private conversation or in a public space?
+ * Is the situation isolated or ongoing?
+ * How is the reported person's behavior negatively impacting others?
+ * Does the incident impact the ability of individuals to freely contribute to LDK?
+ * Does this incident include sexual harassment?
+ * Does this pose a safety risk or severely negatively impact someone's mental health?
+ * Is there a risk of this behavior being repeated?
+ * Does the reported person understand why their behavior was inappropriate?
+
+If a report is insufficiently detailed or involves multiple parties, the Code of Conduct Team may seek additional information from witnesses or the accused. Neither party should contact the other to discuss the incident. Likewise, the team will do its best not to disclose who reported a given incident, either to the accused or generally, though we recognize that circumstantial disclosures to the accused might be unavoidable.
+
+The Code of Conduct Team aims to resolve all reports within one week. If a resolution is not possible within that time frame, the team will respond to the reporter(s) with an adjusted one.
+
+## Possible responses to an incident include:
+
+### Taking no further action:
+If the Code of Conduct Team determines that no action is needed, they will inform the reporter.
+
+### Simple warning:
+This applies to disruptive behavior, but not insulting behavior. The Code of Conduct Team will contact the individual(s) and request that they stop.
+
+### Final warning:
+If an incident or series of incidents creates sustained toxicity within the LDK Community, the Code of Conduct Team will sternly warn the reported party and raise the possibility of further disciplinary action. In addition, they may request that the reported party:
+ * Not use specific language
+ * Not participate in specific types of discussions
+ * Not send private messages to a community member
+ * Not review a particular person's PRs on GitHub (but still allow them to privately share review comments with a maintainer)
+ * Not lead sub-projects like code review sessions
+ * Take a step away for a short period to cool off
+ * Lose maintainer/merge access
+
+### 2-3 months imposed break:
+If the Code of Conduct Team’s warning goes unheeded, the individual(s) may be asked to avoid participating with the LDK Community on its preferred platforms for several months. After time has passed, the individual(s) will have the option of meeting with the team to discuss returning to the community.
+
+### Extended or permanent ban:
+If a temporary break does not remedy a serious offense, the offender may be removed from the Discord server and Github repository. The Code of Conduct Team may also choose to un-ban a user for a first offense, depending on its severity and pending that the user has offered the offended party a genuine apology.


### PR DESCRIPTION
Hopefully this will never be needed in any way, but in general we want to ensure that its documented that, above all else, everyone should act in a way that fosters an open community and ensures anyone can freely contribute to LDK.

Needs a contact email for me and devrandom, and probably needs some kind of link to the page from...somewhere, not sure exactly how to do that here (@ConorOkus any suggestions?), but I think the text is reasonable and draws a good line between not policing anyone's behavior outside of LDK and ensuring that everyone can feel welcome contributing to LDK.