### PR TITLE
Fix docs for moved `broadcast_node_announcement`

### DIFF
--- a/docs/tutorials/build_a_node_in_rust.md
+++ b/docs/tutorials/build_a_node_in_rust.md
@@ -809,6 +809,6 @@ loop {
 }
 ```
 
-**Dependencies:** `ChannelManager`
+**Dependencies:** `PeerManager`
 
-**References:** [`ChannelManager::broadcast_node_announcement` docs](https://docs.rs/lightning/*/lightning/ln/channelmanager/struct.ChannelManager.html#method.broadcast_node_announcement)
+**References:** [`PeerManager::broadcast_node_announcement` docs](https://docs.rs/lightning/*/lightning/ln/peer_handler/struct.PeerManager.html#method.broadcast_node_announcement)


### PR DESCRIPTION
As it been moved to `PeerManager` since ~0.0.110.