### PR TITLE
links: fix architecture broken link.

### DIFF
--- a/docs/building-a-node-with-ldk/handling-events.md
+++ b/docs/building-a-node-with-ldk/handling-events.md
@@ -1,6 +1,6 @@
 # Handling Events
 
-LDK requires that you handle many different events throughout your app's life cycle. You can learn more by reading about our event-driven [architecture](/overview/architecture.md).
+LDK requires that you handle many different events throughout your app's life cycle. You can learn more by reading about our event-driven [architecture](/introduction/architecture.md).
 
 To start handling events in your application, run:
 

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -26,7 +26,7 @@ provide a useful overview of Rust Lightning in the context of language bindings.
 The sample serves as a complete reference for constructing a Lightning node with
 the LDK. This is a good starting point if you want a self-guided tour!
 
-### [Architecture](../overview/architecture)
+### [Architecture](architecture.md)
 
 Gives a high-level organization of LDK and how the pieces fit together. Variations of this diagram
 are used throughout the site. This is the primary source and is still a work in progress.


### PR DESCRIPTION
As shown in [this issue](https://github.com/lightningdevkit/lightningdevkit.org/issues/260), the `architecture` link is broken in two places:
- `introduction/`
- `building-a-node-with-ldk/handling-events/`