### PR TITLE
Appropriate comment to explain timestampSeconds and timestampNanos variables

### DIFF
--- a/docs/key_management.md
+++ b/docs/key_management.md
@@ -116,6 +116,7 @@ let ldkDerivationPath = try DerivationPath(path: "m/535h")
 let ldkChild = try bip32RootKey.derive(path: ldkDerivationPath)
 let ldkSeed = ldkChild.secretBytes()
 
+// Retrieve the current system time for uniqueness across restarts.
 let timestampSeconds = UInt64(NSDate().timeIntervalSince1970)
 let timestampNanos = UInt32(truncating: NSNumber(value: timestampSeconds * 1000 * 1000))
 


### PR DESCRIPTION


The above comment explains that the timestampSeconds and timestampNanos variables are used to capture the current system time, which is then utilized to ensure uniqueness across multiple instances or restarts of the application.