### PR TITLE
case-studies: Fix Lexe links

### DIFF
--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -163,8 +163,8 @@ lastUpdated: false
     <p>A standalone daemon that aims to externally implement BOLT 12 functionality for LND</p>
   </div>
   <div class="case-study-item">
-    <a href="https://github.com/lexe-tech" target="_blank"><img src="./assets/lexe.png" /></a>
-    <h3><a href="https://github.com/lexe-tech" target="_blank">Lexe</a></h3>
+    <a href="https://lexe.app" target="_blank"><img src="./assets/lexe.png" /></a>
+    <h3><a href="https://lexe.app" target="_blank">Lexe</a></h3>
     <p>Managed non-custodial Lightning nodes inside secure hardware</p>
   </div>
   <div class="case-study-item">
@@ -339,8 +339,8 @@ lastUpdated: false
     <p>An experimentation with tor that adapts the ldk-sample node</p>
    </div>
    <div class="case-study-item">
-    <a href="https://github.com/lexe-tech" target="_blank"> <img src="./assets/lexe.png" /></a>
-    <h3><a href="https://github.com/lexe-tech" target="_blank">Lexe</a></h3>
+    <a href="https://lexe.app" target="_blank"> <img src="./assets/lexe.png" /></a>
+    <h3><a href="https://lexe.app" target="_blank">Lexe</a></h3>
     <p>Managed non-custodial Lightning nodes inside secure hardware</p>
   </div>
    <div class="case-study-item">


### PR DESCRIPTION
The old link is dead. Updates Lexe link to our homepage instead.