### PR TITLE
Add Stable Channels to case studies, remove Aciedo, AtomicDEX, Mercury

### DIFF
--- a/docs/.vitepress/theme/components/CaseStudiesPage.vue
+++ b/docs/.vitepress/theme/components/CaseStudiesPage.vue
@@ -68,13 +68,6 @@ const projects: Project[] = [
     cats: ['mobile'],
   },
   {
-    name: 'Aciedo',
-    url: 'https://github.com/aciedo',
-    img: '/img/aciedo.svg',
-    desc: 'A financial infrastructure suite for developers and users',
-    cats: ['infra'],
-  },
-  {
     name: 'Alby Hub',
     url: 'https://albyhub.com/',
     img: '/img/alby-logo.webp',
@@ -82,13 +75,6 @@ const projects: Project[] = [
     cats: ['web'],
     caseStudy:
       '/blog/alby-hub-uses-ldk-to-offer-a-self-custodial-lightning-wallet-for-everyone/',
-  },
-  {
-    name: 'AtomicDEX',
-    url: 'https://atomicdex.io/en/',
-    img: '/img/atomic.png',
-    desc: 'A multi-coin wallet, bridge, and DEX rolled into one app',
-    cats: ['desktop'],
   },
   {
     name: 'AtomicLightningExchange',
@@ -217,13 +203,6 @@ const projects: Project[] = [
     caseStudy: '/blog/lqwd-liquidity-provider-get-liquidity-when-you-need-it/',
   },
   {
-    name: 'Mercury',
-    url: 'https://mercurywallet.com/',
-    img: '/img/mercury.png',
-    desc: 'A layer 2 bitcoin wallet that enables users to send and swap bitcoin privately',
-    cats: ['mobile', 'desktop'],
-  },
-  {
     name: 'Mutiny',
     url: 'https://mutinywallet.com/',
     img: '/img/mutiny.png',
@@ -255,6 +234,14 @@ const projects: Project[] = [
     cats: ['infra'],
     caseStudy:
       '/blog/sensei-uses-ldk-to-build-a-multi-node-lightning-server-application/',
+  },
+  {
+    name: 'Stable Channels',
+    url: 'https://github.com/toneloc/stable-channels',
+    img: '/img/github.png',
+    imgDark: '/img/github-white.png',
+    desc: 'Keep a portion of your bitcoin at a stable dollar value in self-custodial Lightning channels, built on LDK Node',
+    cats: ['mobile', 'desktop', 'infra'],
   },
   {
     name: 'TEOS',


### PR DESCRIPTION
Adds Stable Channels — a self-custodial app built on LDK Node that keeps a portion of a bitcoin balance pegged to a stable dollar value via p2p Lightning channels — to the case studies grid under the Mobile, Desktop, and Infrastructure categories, using the shared GitHub logo with its dark-mode variant. Also removes Aciedo, AtomicDEX, and Mercury from the listing.

Verified with `npm run build:vitepress`, which completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
